### PR TITLE
Add rust v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,9 +447,9 @@ RULE:   apply to them. In addition
 RULE:   - Rust builds using librust-*-dev packges will populate the attribute
 RULE:     `X-Cargo-Built-Using`, right now this is expected not to be present.
 RULE:   - It is expected rust builds will use dh-cargo so that a later switch
-RULE:     to proper package dependencies isn't too hard (e.g. it is likely
-RULE:     that over time some more common/stable libs shall come from proper
-RULE:     archive packages).
+RULE:     to non vendored dependencies isn't too complex (e.g. it is likely
+RULE:     that over time more common libs shall become stable and then archive
+RULE:     packages will be used to build).
 RULE: - All vendored dependencies (no matter what language) shall have a
 RULE:   way to be refreshed (recommended is a documentation README.source and
 RULE:   scripts in debian/

--- a/README.md
+++ b/README.md
@@ -451,6 +451,10 @@ RULE:   - It is expected rust builds will use dh-cargo so that a later switch
 RULE:     to non vendored dependencies isn't too complex (e.g. it is likely
 RULE:     that over time more common libs shall become stable and then archive
 RULE:     packages will be used to build).
+RULE:   - the rust tooling e.g. dh-cargo can not yet automatically provide
+RULE:     all that we require - for example Cargo.lock - until it does the
+RULE:     package build shall be adapted in a way to provide that without
+RULE:     dh* tooling support.
 RULE: - All vendored dependencies (no matter what language) shall have a
 RULE:   way to be refreshed
 TODO-A: - This does not use static builds

--- a/README.md
+++ b/README.md
@@ -609,8 +609,8 @@ RULE:   libraries during this period, the MIR team decided for 17.10 and later
 RULE:   to allow static builds of golang packages in main, so long as the number
 RULE:   of these packages remains low and they follow the guidelines below:
 RULE:   - golang applications in main are expected:
-RULE:       1. to build golang use `golang-*-dev` packages creating
-RULE:          `Built-Using` in debian/control. This requirement ensures
+RULE:       1. to build using `golang-*-dev` packages from the Ubuntu archive
+RULE:          creating `Built-Using` in debian/control. This requirement ensures
 RULE:          that the security team is able to track security issues for all
 RULE:          affected static binary packages
 RULE:       2. not to build any vendored (i.e. embedded) code in the source

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ TODO-A: - The package will be installed by default, but does not ask debconf
 TODO-A:   questions higher than medium
 TODO-B: - The package will not be installed by default
 
-RULE  - The source packaging (in debian/) should be reasonably easy to
+RULE:  - The source packaging (in debian/) should be reasonably easy to
 RULE:   understand and maintain.
 TODO-A: - Packaging and build is easy, link to d/rules TBD
 TODO-B: - Packaging is complex, but that is ok because TBD
@@ -381,7 +381,7 @@ RULE: to its complexity:
 RULE: - All packages must have a designated "owning" team, regardless of
 RULE:   complexity, which is set as a package bug contact. This is not a
 RULE:   requirement for the MIR team ACK, but for the package to be promoted
-RULE    by an archive admin. Still, it is strongly suggested to subscribe,
+RULE:   by an archive admin. Still, it is strongly suggested to subscribe,
 RULE:   as the owning team will get a preview of the to-be-expected incoming
 RULE:   bugs later on.
 RULE: - Simple packages (e.g. language bindings, simple Perl modules, small
@@ -635,7 +635,7 @@ RULE:    golang packages coordinating on transitions and the requesting team
 RULE:    occasionally creating new `golang-*-dev` packages as agreed to in the
 RULE:    MIR bug (upstreaming to Debian whenever possible).
 RULE: - As a practical matter, golang/rust source packages in main are not
-RULE    required to remove unused embedded code copies.
+RULE:   required to remove unused embedded code copies.
 RULE: - If based on the above options it's a statically compiled golang package:
 RULE:   - Does the package use dh-golang (if not, suggest dh-make-golang to
 RULE:     create the package)?

--- a/README.md
+++ b/README.md
@@ -451,8 +451,7 @@ RULE:     to non vendored dependencies isn't too complex (e.g. it is likely
 RULE:     that over time more common libs shall become stable and then archive
 RULE:     packages will be used to build).
 RULE: - All vendored dependencies (no matter what language) shall have a
-RULE:   way to be refreshed (recommended is a documentation README.source and
-RULE:   scripts in debian/
+RULE:   way to be refreshed
 TODO-A: - This does not use static builds
 TODO-B: - The team TBD is aware of the implications by a static build and
 TODO-B:   commits to test no-change-rebuilds and to fix any issues found for the
@@ -464,13 +463,17 @@ TODO-B:   alerted by the security team) commits to provide updates and backports
 TODO-B:   to the security team for any affected vendored code for the lifetime
 TODO-B:   of the release (including ESM).
 
+TODO-A: - This does not use vendored code
+TODO-B: - This package uses vendored go code tracked in go.mod as shiped in the
+TODO-B:   package, refreshing that code works via `go mod ...`.
+TODO-C: - This package uses vendored rust code tracked in Cargo.lock as shipped,
+TODO-C:   in the package, refreshing that code works via `cargo update ...`.
+TODO-D: - This package uses vendored code, refreshing that code is outlined
+TODO-D:   in debian/README.source
+
 TODO-A: - This package is not rust based
 TODO-B: - This package is rust based and vendors all non language-runtime
 TODO-B:   dependencies
-
-TODO-A: - This package is not rust based
-TODO-B: - This package is rust based, refreshing vendored code is outlined
-TODO-B:   in <TBD>
 
 RULE: - if there has been an archive test rebuild that has occurred more recently
 RULE:   than the last upload, the package must have rebuilt successfully

--- a/README.md
+++ b/README.md
@@ -426,15 +426,39 @@ RULE:     - the owning team will provide timely, high quality updates for the
 RULE:       security team to sponsor to fix issues in the affected vendored code
 RULE:     - if subsequent uploads add new vendored components or dependencies
 RULE:       these have to be reviewed and agreed by the security team.
+RULE: - The rust ecosystem currently isn't yet considered stable enough for
+RULE:   classic lib dependencies and transitions in main; therefore the
+RULE:   expectation for those packages is to vendor (and own/test) all
+RULE:   dependencies (except those provided by the rust runtime itself).
+RULE:   This implies that all the rules for vendored builds always
+RULE:   apply to them. In addition
+RULE:   - Rust builds using librust-*-dev packges will populate the attribute
+RULE:     `X-Cargo-Built-Using`, right now this is expected not to be present.
+RULE:   - It is expected rust builds will use dh-cargo so that a later switch
+RULE:     to proper package dependencies isn't too hard (e.g. it is likely
+RULE:     that over time some more common/stable libs shall come from proper
+RULE:     archive packages).
+RULE: - All vendored dependencies (no matter what language) shall have a
+RULE:   way to be refreshed (recommended is a documentation README.source and
+RULE:   scripts in debian/
 TODO-A: - This does not use static builds
 TODO-B: - The team TBD is aware of the implications by a static build and
 TODO-B:   commits to test no-change-rebuilds and to fix any issues found for the
 TODO-B:   lifetime of the release (including ESM)
+
 TODO-A: - This does not use vendored code
 TODO-B: - The team TBD is aware of the implications of vendored code and (as
 TODO-B:   alerted by the security team) commits to provide updates to the security
 TODO-B:   team for any affected vendored code for the lifetime of the release
 TODO-B:   (including ESM).
+
+TODO-A: - This package is not rust based
+TODO-B: - This package is rust based and vendors all non language-runtime
+TODO-B:   dependencies
+
+TODO-A: - This package is not rust based
+TODO-B: - This package is rust based, refreshing vendored code is outlined
+TODO-B:   in <TBD>
 
 RULE: - if there has been an archive test rebuild that has occurred more recently
 RULE:   than the last upload, the package must have rebuilt successfully
@@ -603,6 +627,15 @@ TODO-B:   - No vendoring used, all Built-Using are in main
 TODO-A:   - golang: shared builds
 TODO-B:   - golang: static builds are used, the team confirmed their commitment
 TODO-B:     to the additional responsibilities implied by static builds.
+
+TODO-A: - not a rust package, no extra constraints to consider in that regard
+TODO-B: - rust package that has all dependencies vendored
+TODO-B: - rust package does not have X-Cargo-Built-Using (after build)
+TODO-B: - rust package does use dh_cargo (dh ... --buildsystem cargo)
+
+TODO-A: - Includes vendored code, the package has documented how to refresh this
+TODO-A:   code at <TBD>
+TODO-B: - Does not include vendored code
 
 TODO-A: Problems:
 TODO-A: - TBD

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ TODO-B:     to the additional responsibilities implied by static builds.
 
 TODO-A: - not a rust package, no extra constraints to consider in that regard
 TODO-B: - Rust package that has all dependencies vendored. It does neither
-TODO-B:   have *Built-Using (after build). Nor does the biuld log indicate
+TODO-B:   have *Built-Using (after build). Nor does the build log indicate
 TODO-B:   built-in sources that are missed to be reported as Built-Using.
 
 TODO: - rust package using dh_cargo (dh ... --buildsystem cargo)

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ TODO-B:   to the security team for any affected vendored code for the lifetime
 TODO-B:   of the release (including ESM).
 
 TODO-A: - This does not use vendored code
-TODO-B: - This package uses vendored go code tracked in go.mod as shiped in the
+TODO-B: - This package uses vendored go code tracked in go.sum as shiped in the
 TODO-B:   package, refreshing that code is outlined in debian/README.source
 TODO-C: - This package uses vendored rust code tracked in Cargo.lock as shipped,
 TODO-C:   in the package (at /usr/share/doc/<pkgname>/Cargo.lock - might be
@@ -588,7 +588,10 @@ RULE:     the remaining (currently vendored) dependencies shall be tracked
 RULE:     in a cargo.lock file
 RULE:   - Go - here `Built-Using` is expected to only contain the go
 RULE:     toolchain used to build it. Additional dependencies shall be
-RULE:     tracked in a go.mod file
+RULE:     tracked in a go.sum file (go.mod are direct dependencies, go.sum
+RULE:     covers checksum content for direct and indirect dependencies. This
+RULE:     should be present for reproducible builds already which involve
+RULE:     having a go.sum.
 
 OK:
 TODO: - no embedded source present

--- a/README.md
+++ b/README.md
@@ -443,9 +443,13 @@ RULE:   classic lib dependencies and transitions in main; therefore the
 RULE:   expectation for those packages is to vendor (and own/test) all
 RULE:   dependencies (except those provided by the rust runtime itself).
 RULE:   This implies that all the rules for vendored builds always
-RULE:   apply to them. In addition
+RULE:   apply to them. In addition:
+RULE:   - The rules and checks for rust based packges are preliminary and might
+RULE:     change while finalizing the rust toolchain in main and while
+RULE:     processing the first few rust based packages.
 RULE:   - Rust builds using librust-*-dev packges will populate the attribute
-RULE:     `X-Cargo-Built-Using`, right now this is expected not to be present.
+RULE:     `Built-Using`, right now this is expected not to be present as
+RULE:      - for now - all rust dependencies shall be vendored.
 RULE:   - It is expected rust builds will use dh-cargo so that a later switch
 RULE:     to non vendored dependencies isn't too complex (e.g. it is likely
 RULE:     that over time more common libs shall become stable and then archive
@@ -576,6 +580,10 @@ RULE:   is discouraged unless static linking is required for the package in
 RULE:   question to function correctly (e.g. an integrity scanner).
 RULE: - Does debian/control use `Built-Using`? This may indicate static linking
 RULE:   which should be discouraged (except golang/rust, see below)
+RULE:   - Especially for rust - where toolchain and dh tools are new and still
+RULE:     changing a lot - please double check to not only have no Built-Using
+RULE:     entry, but also that there is no code of librust-*-dev used that just
+RULE:     happened to be missed while generating Built-Using.
 
 OK:
 TODO: - no embedded source present
@@ -644,9 +652,11 @@ TODO-B:   - golang: static builds are used, the team confirmed their commitment
 TODO-B:     to the additional responsibilities implied by static builds.
 
 TODO-A: - not a rust package, no extra constraints to consider in that regard
-TODO-B: - rust package that has all dependencies vendored
-TODO-B: - rust package does not have X-Cargo-Built-Using (after build)
-TODO-B: - rust package does use dh_cargo (dh ... --buildsystem cargo)
+TODO-B: - Rust package that has all dependencies vendored. It does neither
+TODO-B:   have *Built-Using (after build). Nor does the biuld log indicate
+TODO-B:   built-in sources that are missed to be reported as Built-Using.
+
+TODO: - rust package using dh_cargo (dh ... --buildsystem cargo)
 
 TODO-A: - Includes vendored code, the package has documented how to refresh this
 TODO-A:   code at <TBD>

--- a/README.md
+++ b/README.md
@@ -444,8 +444,8 @@ RULE:   expectation for those packages is to vendor (and own/test) all
 RULE:   dependencies (except those provided by the rust runtime itself).
 RULE:   This implies that all the rules for vendored builds always
 RULE:   apply to them. In addition:
-RULE:   - The rules and checks for rust based packges are preliminary and might
-RULE:     change while finalizing the rust toolchain in main and while
+RULE:   - The rules and checks for rust based packages are preliminary and might
+RULE:     change over time as the ecosytem matures and while
 RULE:     processing the first few rust based packages.
 RULE:   - Rust builds using librust-*-dev packges will populate the attribute
 RULE:     `Built-Using`, right now this is expected not to be present as

--- a/README.md
+++ b/README.md
@@ -399,8 +399,8 @@ TODO-A: - Team is already subscribed to the package
 TODO-B: - Team is not yet, but will subscribe to the package before promotion
 
 RULE: - Responsibilities implied by static builds promoted to main, which is
-RULE:   not a recommended but a common case with golang packages.
-RULE:   - the security team will track CVEs for all golang packages in main
+RULE:   not a recommended but a common case with golang and rust packages.
+RULE:   - the security team will track CVEs for all vendored packages in main
 RULE:   - the security team will provide updates to main for all `golang-*-dev`
 RULE:     packages
 RULE:   - the security team will provide updates to main for non-vendored
@@ -536,7 +536,7 @@ RULE:   maintenance burden. For this reason, static linking in archive builds
 RULE:   is discouraged unless static linking is required for the package in
 RULE:   question to function correctly (e.g. an integrity scanner).
 RULE: - Does debian/control use `Built-Using`? This may indicate static linking
-RULE:   which should be discouraged (except golang, see below)
+RULE:   which should be discouraged (except golang/rust, see below)
 
 OK:
 TODO: - no embedded source present
@@ -579,8 +579,8 @@ RULE:    adjusting their packaging as necessary, all teams responsible for
 RULE:    golang packages coordinating on transitions and the requesting team
 RULE:    occasionally creating new `golang-*-dev` packages as agreed to in the
 RULE:    MIR bug (upstreaming to Debian whenever possible).
-RULE: - As a practical matter, golang source packages in main are not required
-RULE:   to remove unused embedded code copies.
+RULE: - As a practical matter, golang/rust source packages in main are not
+RULE    required to remove unused embedded code copies.
 RULE: - If based on the above options it's a statically compiled golang package:
 RULE:   - Does the package use dh-golang (if not, suggest dh-make-golang to
 RULE:     create the package)?

--- a/README.md
+++ b/README.md
@@ -447,9 +447,6 @@ RULE:   apply to them. In addition:
 RULE:   - The rules and checks for rust based packages are preliminary and might
 RULE:     change over time as the ecosytem matures and while
 RULE:     processing the first few rust based packages.
-RULE:   - Rust builds using librust-*-dev packges will populate the attribute
-RULE:     `Built-Using`, right now this is expected not to be present as
-RULE:      - for now - all rust dependencies shall be vendored.
 RULE:   - It is expected rust builds will use dh-cargo so that a later switch
 RULE:     to non vendored dependencies isn't too complex (e.g. it is likely
 RULE:     that over time more common libs shall become stable and then archive
@@ -578,12 +575,15 @@ RULE:   with the updated libraries to receive the fix, which increases the
 RULE:   maintenance burden. For this reason, static linking in archive builds
 RULE:   is discouraged unless static linking is required for the package in
 RULE:   question to function correctly (e.g. an integrity scanner).
-RULE: - Does debian/control use `Built-Using`? This may indicate static linking
+RULE: - If debian/control uses `Built-Using` it may indicate static linking
 RULE:   which should be discouraged (except golang/rust, see below)
-RULE:   - Especially for rust - where toolchain and dh tools are new and still
-RULE:     changing a lot - please double check to not only have no Built-Using
-RULE:     entry, but also that there is no code of librust-*-dev used that just
-RULE:     happened to be missed while generating Built-Using.
+RULE:   - Rust - toolchain and dh tools are still changing a lot. Currently it
+RULE:     is expected to only list the rust toolchain in `Built-Using`.
+RULE:     the remaining (currently vendored) dependencies shall be tracked
+RULE:     in a cargo.lock file
+RULE:   - Go - here `Built-Using` is expected to only contain the go
+RULE:     toolchain used to build it. Additional dependencies shall be
+RULE:     tracked in a go.mod file
 
 OK:
 TODO: - no embedded source present

--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ RULE:   - Does debian/control use `Built-Using: ${misc:Built-Using}` for each
 RULE:     non'-dev' binary package (importantly, golang-*-dev packages only
 RULE:     ship source files so don't need Built-Using)?
 RULE:   - Does the package follow
-RULE:     [[http://pkg-go.alioth.debian.org/packaging.html|Debian Go packaging]]
+RULE:     [[https://go-team.pages.debian.net/packaging.html|Debian Go packaging]]
 RULE:     guidelines?
 RULE: - When it is infeasible to comply with this policy, the justification,
 RULE:   discussion and approval should all be clearly represented in the bug.

--- a/README.md
+++ b/README.md
@@ -451,10 +451,26 @@ RULE:   - It is expected rust builds will use dh-cargo so that a later switch
 RULE:     to non vendored dependencies isn't too complex (e.g. it is likely
 RULE:     that over time more common libs shall become stable and then archive
 RULE:     packages will be used to build).
-RULE:   - the rust tooling e.g. dh-cargo can not yet automatically provide
-RULE:     all that we require - for example Cargo.lock - but that will be
-RULE:     required to track dependencies. Until available in e.g. dh-cargo
-RULE:     a package can not yet get fully compliant.
+RULE:   - Right now that tooling to get a Cargo.lock that will include internal
+RULE:     vendored dependencies isn't in place yet (expect a dh-cargo change
+RULE:     later). Until it is available, as a fallback one can scan the
+RULE:     directory at build time and let it be generated in debian/rules.
+RULE:     An example might look like:
+RULE:       d/rules:
+RULE:         override_dh_auto_test:
+RULE:             CARGO_HOME=debian /usr/share/cargo/bin/cargo test --offline
+RULE:       d/<pkg>.install:
+RULE:         Cargo.lock /usr/share/doc/<pkg>
+RULE:       d/config.toml
+RULE:         # Use the vendorized sources to produce the Cargo.lock file. This
+RULE:         # can be performed by pointing $CARGO_HOME to the path containing
+RULE:         # this file.
+RULE:         [source]
+RULE:         [source.my-vendor-source]
+RULE:         directory = "vendor"
+RULE:         [source.crates-io]
+RULE:         replace-with = "my-vendor-source"
+
 RULE: - All vendored dependencies (no matter what language) shall have a
 RULE:   way to be refreshed
 TODO-A: - This does not use static builds
@@ -587,10 +603,10 @@ RULE:   - Rust - toolchain and dh tools are still changing a lot. Currently it
 RULE:     is expected to only list the rust toolchain in `Built-Using`.
 RULE:     the remaining (currently vendored) dependencies shall be tracked
 RULE:     in a cargo.lock file
-RULE:     Right now that tooling to get a cargo.lock that will include internal
-RULE:     packaged (if any) and used vendored dependencies isn't in place.
-RULE:     So right now due to the lack of that for example in dh-cargo one
-RULE:     can not yet get a package fully compliant.
+RULE:     - The rust tooling can not yet automatically provide all we require.
+RULE:       For example Cargo.lock - until available a package is at least
+RULE:       expected to generate this file itself at build time - an example
+RULE:       how to do so is shown above in the template for the reporter.
 RULE:   - Go - here `Built-Using` is expected to only contain the go
 RULE:     toolchain used to build it. Additional packaged dependencies
 RULE:     will be tracked in `Static-Built-Using:` automatically.

--- a/README.md
+++ b/README.md
@@ -403,13 +403,12 @@ RULE:   not a recommended but a common case with golang packages.
 RULE:   - the security team will track CVEs for all golang packages in main
 RULE:   - the security team will provide updates to main for all `golang-*-dev`
 RULE:     packages
-RULE:   - the security team will provide updates to main for golang applications
-RULE:     whose non-vendored source code is affected as per normal procedures
-RULE:     (including e.g., sponsoring/coordinating uploads from teams/upstream
-RULE:     projects, etc)
+RULE:   - the security team will provide updates to main for non-vendored
+RULE:     dependencies as per normal procedures (including e.g.,
+RULE:     sponsoring/coordinating uploads from teams/upstream projects, etc)
 RULE:   - the security team will perform no-change-rebuilds for all packages
-RULE:     Built-Using `golang-*-dev` packages it has provided, and coordinate
-RULE:     testing with the owning teams responsible for the rebuilt packages
+RULE:     listing an CVE-fixed package as Built-Using and coordinate testing
+RULE:     with the owning teams responsible for the rebuilt packages
 RULE:   - for packages that build using any `golang-*-dev` packages:
 RULE:     - the owning team must state their commitment to test
 RULE:       no-change-rebuilds triggered by a dependent library/compiler and to
@@ -542,7 +541,7 @@ RULE:   which should be discouraged (except golang, see below)
 OK:
 TODO: - no embedded source present
 TODO: - no static linking
-TODO: - does not have odd Built-Using entries
+TODO: - does not have unexpected Built-Using entries
 
 RULE: Golang
 RULE: - golang 1.4 packages and earlier could only statically compile their
@@ -558,8 +557,8 @@ RULE:   libraries during this period, the MIR team decided for 17.10 and later
 RULE:   to allow static builds of golang packages in main, so long as the number
 RULE:   of these packages remains low and they follow the guidelines below:
 RULE:   - golang applications in main are expected:
-RULE:       1. to build using `golang-*-dev` packages from the Ubuntu archive
-RULE:          with `Built-Using` in debian/control. This requirement ensures
+RULE:       1. to build golang use `golang-*-dev` packages creating
+RULE:          `Built-Using` in debian/control. This requirement ensures
 RULE:          that the security team is able to track security issues for all
 RULE:          affected static binary packages
 RULE:       2. not to build any vendored (i.e. embedded) code in the source

--- a/README.md
+++ b/README.md
@@ -452,9 +452,9 @@ RULE:     to non vendored dependencies isn't too complex (e.g. it is likely
 RULE:     that over time more common libs shall become stable and then archive
 RULE:     packages will be used to build).
 RULE:   - the rust tooling e.g. dh-cargo can not yet automatically provide
-RULE:     all that we require - for example Cargo.lock - until it does the
-RULE:     package build shall be adapted in a way to provide that without
-RULE:     dh* tooling support.
+RULE:     all that we require - for example Cargo.lock - but that will be
+RULE:     required to track dependencies. Until available in e.g. dh-cargo
+RULE:     a package can not yet get fully compliant.
 RULE: - All vendored dependencies (no matter what language) shall have a
 RULE:   way to be refreshed
 TODO-A: - This does not use static builds
@@ -580,18 +580,29 @@ RULE:   with the updated libraries to receive the fix, which increases the
 RULE:   maintenance burden. For this reason, static linking in archive builds
 RULE:   is discouraged unless static linking is required for the package in
 RULE:   question to function correctly (e.g. an integrity scanner).
-RULE: - If debian/control uses `Built-Using` it may indicate static linking
+RULE: - If debian/control uses `Built-Using` or `Static-Built-Using:` it may
+RULE:   indicate static linking
 RULE:   which should be discouraged (except golang/rust, see below)
 RULE:   - Rust - toolchain and dh tools are still changing a lot. Currently it
 RULE:     is expected to only list the rust toolchain in `Built-Using`.
 RULE:     the remaining (currently vendored) dependencies shall be tracked
 RULE:     in a cargo.lock file
+RULE:     Right now that tooling to get a cargo.lock that will include internal
+RULE:     packaged (if any) and used vendored dependencies isn't in place.
+RULE:     So right now due to the lack of that for example in dh-cargo one
+RULE:     can not yet get a package fully compliant.
 RULE:   - Go - here `Built-Using` is expected to only contain the go
-RULE:     toolchain used to build it. Additional dependencies shall be
+RULE:     toolchain used to build it. Additional packaged dependencies
+RULE:     will be tracked in `Static-Built-Using:` automatically.
+RULE:     The superset of packaged and vendored (if used) dependencies shall be
 RULE:     tracked in a go.sum file (go.mod are direct dependencies, go.sum
 RULE:     covers checksum content for direct and indirect dependencies. This
 RULE:     should be present for reproducible builds already which involve
 RULE:     having a go.sum.
+RULE:     We have let go packages into main before this existed, so we have
+RULE:     sub-optimal prior-art. But down the road - if vendoring is used - we
+RULE:     want to switch to require that once the toolchain is ready to
+RULE:     create it accordingly.
 
 OK:
 TODO: - no embedded source present

--- a/README.md
+++ b/README.md
@@ -426,6 +426,18 @@ RULE:     - the owning team will provide timely, high quality updates for the
 RULE:       security team to sponsor to fix issues in the affected vendored code
 RULE:     - if subsequent uploads add new vendored components or dependencies
 RULE:       these have to be reviewed and agreed by the security team.
+RULE:     - Such updates in the project might be trivial, but imply that a
+RULE:       dependency for e.g. a CVE fix will be moved to a new major version.
+RULE:       Being vendored that does gladly at least not imply incompatibility
+RULE:       issues with other packages or the SRU policy. But it might happen
+RULE:       that this triggers either:
+RULE:       a) The need to adapt the current version of the main package and/or
+RULE:          other vendored dependencies to work with the new dependency
+RULE:       b) The need to backport the fix in the dependency as the main
+RULE:          package will functionally only work well with the older version
+RULE:       c) The need to backport the fix in the dependency, as it would imply
+RULE:          requiring a newer toolchain to be buildable that isn't available
+RULE:          in the target release.
 RULE: - The rust ecosystem currently isn't yet considered stable enough for
 RULE:   classic lib dependencies and transitions in main; therefore the
 RULE:   expectation for those packages is to vendor (and own/test) all
@@ -448,9 +460,9 @@ TODO-B:   lifetime of the release (including ESM)
 
 TODO-A: - This does not use vendored code
 TODO-B: - The team TBD is aware of the implications of vendored code and (as
-TODO-B:   alerted by the security team) commits to provide updates to the security
-TODO-B:   team for any affected vendored code for the lifetime of the release
-TODO-B:   (including ESM).
+TODO-B:   alerted by the security team) commits to provide updates and backports
+TODO-B:   to the security team for any affected vendored code for the lifetime
+TODO-B:   of the release (including ESM).
 
 TODO-A: - This package is not rust based
 TODO-B: - This package is rust based and vendors all non language-runtime

--- a/README.md
+++ b/README.md
@@ -472,8 +472,8 @@ TODO-A: - This does not use vendored code
 TODO-B: - This package uses vendored go code tracked in go.mod as shiped in the
 TODO-B:   package, refreshing that code is outlined in debian/README.source
 TODO-C: - This package uses vendored rust code tracked in Cargo.lock as shipped,
-TODO-C:   in the package, refreshing that code is outlined in
-TODO-C:   debian/README.source
+TODO-C:   in the package (at /usr/share/doc/<pkgname>/Cargo.lock - might be
+TODO-C:   compressed), refreshing that code is outlined in debian/README.source
 TODO-D: - This package uses vendored code, refreshing that code is outlined
 TODO-D:   in debian/README.source
 

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ TODO-B: - Team is not yet, but will subscribe to the package before promotion
 
 RULE: - Responsibilities implied by static builds promoted to main, which is
 RULE:   not a recommended but a common case with golang and rust packages.
-RULE:   - the security team will track CVEs for all vendored packages in main
+RULE:   - the security team will track CVEs for all vendored/embedded sources in main
 RULE:   - the security team will provide updates to main for all `golang-*-dev`
 RULE:     packages
 RULE:   - the security team will provide updates to main for non-vendored

--- a/README.md
+++ b/README.md
@@ -466,9 +466,10 @@ TODO-B:   of the release (including ESM).
 
 TODO-A: - This does not use vendored code
 TODO-B: - This package uses vendored go code tracked in go.mod as shiped in the
-TODO-B:   package, refreshing that code works via `go mod ...`.
+TODO-B:   package, refreshing that code is outlined in debian/README.source
 TODO-C: - This package uses vendored rust code tracked in Cargo.lock as shipped,
-TODO-C:   in the package, refreshing that code works via `cargo update ...`.
+TODO-C:   in the package, refreshing that code is outlined in
+TODO-C:   debian/README.source
 TODO-D: - This package uses vendored code, refreshing that code is outlined
 TODO-D:   in debian/README.source
 


### PR DESCRIPTION
Hi,
this is the successor of the [former discussion here](https://github.com/cpaelzer/ubuntu-mir/pull/3) which has now been rebased and updated to match the current state.

Since the last time we discussed this rustc itself is in main and we have a new Ubuntu release going on.
Some other things have settled and some others (e.g. creating cargo.lock in dh-cargo) have not.

We also have internally prepared our test-package [mdevctl](https://bugs.launchpad.net/ubuntu/+source/mdevctl/+bug/1942394) to present it for review to the MIR team after we have settled on the rules we want to initially have for rust.

Most old discussions became spin-offs into minor details or late additions.
Therefore I have re-started this and rebased it onto the new GH based markdown content and wanted to present it to the MIR team to discuss and vote on adding that.