### PR TITLE
Fix typo in bug template: `TODO-B` -> `TODO-A`

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ TODO-B:   intltool/gettext or similar build and runtime internationalization
 TODO-B:   system see TBD
 
 TODO-A: - End-user applications that ships a standard conformant desktop file,
-TODO-B:   see TBD
+TODO-A:   see TBD
 TODO-B: - End-user applications without desktop file, not needed because TBD
 
 [Dependencies]


### PR DESCRIPTION
When I recently worked on an MIR, I stumbled upon this (in the `[UI standards]` section).

> _TODO-A: - End-user applications that ships a standard conformant desktop file,_
> _**TODO-B:   see TBD**_
> _TODO-B: - End-user applications without desktop file, not needed because TBD_

I assume that the _"see TBD"_ corresponds to `TODO-A` and not `TODO-B`.