### PR TITLE
Add a new PR review section to the weekly meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -901,6 +901,11 @@ Mission: Identify required actions and spread the load among the teams
 
 #link https://bugs.launchpad.net/ubuntu/?field.searchtext=&orderby=-date_last_updated&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&field.subscriber=ubuntu-mir
 
+#topic Process/Documentation improvements
+Mission: Review pending process/documentation pull-requests
+
+#link https://github.com/canonical/ubuntu-mir/pulls
+
 #topic MIR related Security Review Queue
 Mission: Check on progress, do deadlines seem doable?
 

--- a/README.md
+++ b/README.md
@@ -892,7 +892,7 @@ Mission: Identify required actions and spread the load among the teams
 #link https://people.canonical.com/~ubuntu-archive/component-mismatches.svg
 
 #topic New MIRs
-Mission: ensure to assign all incoming reviews for fast processing  
+Mission: ensure to assign all incoming reviews for fast processing
 
 #link https://bugs.launchpad.net/ubuntu/?field.searchtext=&orderby=-date_last_updated&field.status%3Alist=NEW&field.status%3Alist=CONFIRMED&assignee_option=none&field.assignee=&field.subscriber=ubuntu-mir
 


### PR DESCRIPTION
We've seen plenty of contributions to https://github.com/canonical/ubuntu-mir/pulls recently. We should make it a weekly habbit to check any new/pending PRs and give our +1/-1 to get those landed quickly.