### PR TITLE
require a single Launchpad bug for each MIR request

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,7 @@ The reporter/reviewer is tasked to use the templates the following way:
 1. You can and are encouraged to always add more details/background that make the case comprehensible
 1. Update the MIR Bug
    1. Reporter: File the MIR bug based on the processed template as the bug description
-      - In case of a single context/reasoning, but multiple packages to promote please provide the full content for each of them separated with *--- --- --- --- ---* in the description. Be warned that Launchpad can only handle a certain amount of such tasks well, as a best practise if you have more than 10 packages consider splitting things into multiple bugs with one central one for tracking referencing all the others.
    1. MIR-Team: Review and add a comment to the bug that contains the review
-      - In case of a single context/reasoning, but multiple packages MIR reviewers will do one review post per such package.
 
 ## Main Inclusion requirements
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The reporter/reviewer is tasked to use the templates the following way:
 1. You can and are encouraged to always add more details/background that make the case comprehensible
 1. Update the MIR Bug
    1. Reporter: File the MIR bug based on the processed template as the bug description
+      - In case of a single context/reasoning, but multiple packages to promote please make a Launchpad bug for each package. One central package may be chosen to maintain the shared context of related packages. Other packages must be tracked by and link to the central package. See the [central Pacemaker MIR](https://bugs.launchpad.net/ubuntu/+source/pcs/+bug/1953341) as an example.
    1. MIR-Team: Review and add a comment to the bug that contains the review
 
 ## Main Inclusion requirements


### PR DESCRIPTION
Multiple MIR requests in a single Launchpad bug breaks tracking tooling and is less easy to follow compared to one bug per MIR.

This change would require requesters to file a bug for each MIR request and to copy-paste shared context text into each of them.