### PR TITLE
add re-reviews to the MIR process

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ The reporter/reviewer is tasked to use the templates the following way:
       - In case of a single context/reasoning, but multiple packages to promote please make a Launchpad bug for each package. One central package may be chosen to maintain the shared context of related packages. Other packages must be tracked by and link to the central package. See the [central Pacemaker MIR](https://bugs.launchpad.net/ubuntu/+source/pcs/+bug/1953341) as an example.
    1. MIR-Team: Review and add a comment to the bug that contains the review
 
+There is a special aspect for re-reviews. Those will not need to
+re-check everything (they could, but they do not have to) while other
+things only are important on a re-check.
+For that there is a section *[Re-Review]* which has entries only needed for
+that.
+Furthermore any `TODO:` entry that shall be re-checked ona re-review has
+a `*` added before the colon. So it would appear as `TODO*:` or `TODO-A*:`
+respectively.
+That allows for easy filtering while not having redundant rules.
+
 ## Main Inclusion requirements
 
 Use this template for the MIR bug report that you will file.
@@ -546,20 +556,82 @@ By default statements are in the *OK* section, but issues that need to
 be addressed should go to the *Problem:* sections (and briefly the
 summary at the top).
 
+# Re-Reviewing an approved package
+
+The MIR team and thereby in extension Ubuntu continuously evolves the MIR
+ruling. For example, we add rules based on painful lessons learned to avoid
+the same from happening again. In that regard the demand for testing, quality
+and so on might be best practice now, but have not been fulfilled by packages
+that are in main for a long time.
+
+The proposed approach would be to:
+
+1. We will add (doing so is a TODO) a query that helps us to spot packages in main for the longest time without having a recent update on their MIR bugs.
+1. The MIR team would aim for a constant load of e.g. "1 review per week per MIR member"
+   1. Priority would be on new MIRs, whenever we have spare capacity we would pick up old re-reviews
+   1. On one hand that means if new requests are assigned in a week that we make no progress on the backlog
+   1. But on the other hand this keeps effort of MIR team members somewhat plannable
+1. We'd run a trimmed down check which is a subset of our usual check (see below for details)
+   1. Anything we find for packages already in main becomes part of the owning teams backlog. The decision how hard we push on them is a case by case discussion depending on too many variables to properly pre-define.
+1. As on the initial MIR review we might end up recommending a security (re-)review which goes into their queue at low prio
+
+## Packages without a MIR bug
+
+This is a special case for things that are in main for quite some time.
+Those packages are in main without an launchpad bug based MIR process.
+Some have mailing list posts which can serve as a base, but some have
+nothing at all for auditability.
+
+For these cases we'll still do a re-review. But once we have our new result
+we can not post it on an existing MIR bug. Instead we will essentially start
+creating a MIR bug for this package with this being the initial input.
+
+Then we will reach out to the [owning team](http://reqorts.qa.ubuntu.com/reports/m-r-package-team-mapping.html)
+and ask them to look at what we found and also ask them to reply on the bug
+with a full new `MIR` template. That shall help to ensure the owning teams
+point of view is documented as they should ask (and answer) themselfe
+the same questions we expect them to do on any modern MIR.
+
+## Progress and Expectations
+
+We do not expect this to be quick, there are so many old packages in main that
+do not even have any trace how they got promoted.
+But if we never start it will never get better. So instead of holding back,
+being afraid of the volume, we need to just start at some point.
+
+On the other hand this is not meant to be just a one time effort, it should be
+a continuous practise to re-evaluate packages in main.
+Due to the same volume<->velocity considerations a full iteration will likely
+take many years, so a package should not be expected to be rechecked "often".
+
+Since the re-reviewed packages are already in main there can't be any
+conditional ACKs. We mostly fill the backlog of the owning teams.
+
+The urgency of those backlog tasks depend on how bad it is. On one hand we
+will not immediately threaten to demote a package with a small issue.
+But on the other hand, if we find something really bad we want to put quite
+some pressure on the owning team, but that is a case by case decision.
+While on packages already being in main we no more have the formal gate
+of "allow to migrate to main" we still have enough influence without pre
+defining negative consequences (if inactivity to our report really will
+be a problem we can revisit this aspect).
+
+
 ```
 RULE: Since we sometimes have many such posts on one bug in case multiple
 RULE: packages are assocuated clearly state which one this is for.
 TODO: Review for Package: TBDSRC
 
 [Summary]
-TODO: WRITE - TBD The essence of the review result from the MIR POV
-TODO-A: MIR team ACK
-TODO-B: MIR team NACK
+TODO*: WRITE - TBD The essence of the review result from the MIR POV
+TODO-A*: MIR team ACK
+TODO-B*: MIR team NACK
 TODO-C: MIR team ACK under the constraint to resolve the below listed
 TODO-C: required TODOs and as much as possible having a look at the
 TODO-C: recommended TODOs.
-TODO-A: This does need a security review, so I'll assign ubuntu-security
-TODO-B: This does not need a security review
+RULE: This decision is determined by the sum of the [Security] section below.
+TODO-A*: This does need a security review, so I'll assign ubuntu-security
+TODO-B*: This does not need a security review
 TODO: List of specific binary packages to be promoted to main: TBD
 TODO: Specific binary packages built, but NOT to be promoted to main: TBD
 
@@ -595,7 +667,10 @@ RULE: description and check if any of them is in main:
 RULE:   $ rmadison -c main {all,packages,that,look,like,duplicates}
 RULE: If any of them are reported to be in main check in detail if they cover
 RULE: indeed the same use case as the package this MIR is about.
-TODO: There is no other package in main providing the same functionality.
+RULE: On re-review finding duplication might lead to considerations to drop
+RULE: one of the two. They might not have been unifiably back then, but might
+RULE: be nowadays
+TODO*: There is no other package in main providing the same functionality.
 
 [Dependencies]
 OK:
@@ -738,20 +813,27 @@ RULE:   can and then assign to the ubuntu-security team. The bug will then be
 RULE:   added to the prioritized list of MIR security reviews.
 
 OK:
-TODO: - history of CVEs does not look concerning
-TODO: - does not run a daemon as root
-TODO: - does not use webkit1,2
-TODO: - does not use lib*v8 directly
-TODO: - does not parse data formats (files [images, video, audio,
-TODO:   xml, json, asn.1], network packets, structures, ...) from
-TODO:   an untrusted source.
-TODO: - does not open a port/socket
-TODO: - does not process arbitrary web content
-TODO: - does not use centralized online accounts
-TODO: - does not integrate arbitrary javascript into the desktop
-TODO: - does not deal with system authentication (eg, pam), etc)
-TODO: - does not deal with security attestation (secure boot, tpm, signatures)
-TODO: - does not deal with cryptography (en-/decryption, certificates, signing, ...)
+TODO*: - history of CVEs does not look concerning
+TODO*: - does not run a daemon as root
+TODO*: - does not use webkit1,2
+TODO*: - does not use lib*v8 directly
+TODO*: - does not parse data formats (files [images, video, audio,
+TODO*:   xml, json, asn.1], network packets, structures, ...) from
+TODO*:   an untrusted source.
+TODO*: - does not open a port/socket
+TODO*: - does not process arbitrary web content
+TODO*: - does not use centralized online accounts
+TODO*: - does not integrate arbitrary javascript into the desktop
+TODO*: - does not deal with system authentication (eg, pam), etc)
+TODO*: - does not deal with security attestation (secure boot, tpm, signatures)
+TODO*: - does not deal with cryptography (en-/decryption, certificates, signing, ...)
+TODO*: - no use of sudo, gksu, pkexec, or LD_LIBRARY_PATH (usage is OK inside
+TODO*:   tests)
+TODO*: - no use of user nobody
+TODO*: - no use of setuid
+TODO*: - use of setuid, but ok because TBD (prefer systemd to set those
+TODO*:   for services)
+
 
 TODO-A: Problems:
 TODO-A: - TBD
@@ -764,14 +846,14 @@ RULE:   the Main Inclusion requirements
 
 OK:
 TODO: - does not FTBFS currently
-TODO: - does have a test suite that runs at build time
-TODO:   - test suite fails will fail the build upon error.
-TODO: - does have a non-trivial test suite that runs as autopkgtest
-TODO-A: - This does seem to need special HW for build or test so it can't be
-TODO-A:   automatic. Is there a test plan, code, hardware available and
-TODO-A:   committment to cover that continuously?
-TODO-A:   Please outline in detail and provide a sample log of a successful run.
-TODO-B: - This does not need special HW for build or test
+TODO*: - does have a test suite that runs at build time
+TODO*:   - test suite fails will fail the build upon error.
+TODO*: - does have a non-trivial test suite that runs as autopkgtest
+TODO-A*: - This does seem to need special HW for build or test so it can't be
+TODO-A*:   automatic. Is there a test plan, code, hardware available and
+TODO-A*:   committment to cover that continuously?
+TODO-A*:   Please outline in detail and provide a sample log of a successful run.
+TODO-B*: - This does not need special HW for build or test
 TODO: - if a non-trivial test on this level does not make sense (the lib alone
 TODO:   is only doing rather simple things), is the overall solution (app+libs)
 TODO:   extensively covered i.e. via end to end autopkgtest ?
@@ -804,19 +886,20 @@ RULE:   to enforce maintainer awareness and make it more visible to anyone
 RULE:   looking at the package - see https://wiki.ubuntu.com/ToolChain/LTO.
 
 OK:
-TODO-A: - Ubuntu does not carry a delta
-TODO-B: - Ubuntu does carry a delta, but it is reasonable and maintenance under
-TODO-B:   control
-TODO: - symbols tracking is in place
-TODO: - symbols tracking not applicable for this kind of code.
-TODO-A: - debian/watch is present and looks ok (if needed, e.g. non-native)
-TODO-B: - debian/watch is not present but also not needed (e.g. native)
-TODO: - Upstream update history is (good/slow/sporadic)
-TODO: - Debian/Ubuntu update history is (good/slow/sporadic)
-TODO: - the current release is packaged
+TODO-A*: - Ubuntu does not carry a delta
+TODO-B*: - Ubuntu does carry a delta, but it is reasonable and maintenance under
+TODO-B*:   control
+TODO-C*: - Ubuntu does carry delta and it seems it could be simplified or upstreamed
+TODO*: - symbols tracking is in place
+TODO*: - symbols tracking not applicable for this kind of code.
+TODO-A*: - debian/watch is present and works well
+TODO-B*: - debian/watch is not present but also not needed (e.g. native)
+TODO*: - Upstream update history is (good/slow/sporadic)
+TODO*: - Debian/Ubuntu update history is (good/slow/sporadic)
+TODO*: - the current release is packaged
 TODO: - promoting this does not seem to cause issues for MOTUs that so far
 TODO:   maintained the package
-TODO: - no massive Lintian warnings
+TODO*: - no massive Lintian warnings
 TODO: - debian/rules is rather clean
 TODO: - It is not on the lto-disabled list
 RULE:   (fix, or the work-around should be directly in the package,
@@ -834,12 +917,6 @@ OK:
 TODO: - no Errors/warnings during the build
 TODO-A: - no incautious use of malloc/sprintf (as far as we can check it)
 TODO-B: - no incautious use of malloc/sprintf (the language has no direct MM)
-TODO: - no use of sudo, gksu, pkexec, or LD_LIBRARY_PATH (usage is OK inside
-TODO:   tests)
-TODO: - no use of user nobody
-TODO: - no use of setuid
-TODO: - use of setuid, but ok because TBD (prefer systemd to set those
-TODO:   for services)
 TODO: - no important open bugs (crashers, etc) in Debian or Ubuntu
 TODO: - no dependency on webkit, qtwebkit, seed or libgoa-*
 TODO-A: - not part of the UI for extra checks
@@ -850,150 +927,12 @@ TODO-B: - translation present
 TODO-A: Problems:
 TODO-A: - TBD
 TODO-B: Problems: None
-```
 
-
-# Re-Reviewing an approved package
-
-Right now this is **not active**, it is - so far - a documentation of the intent to do so helping all involved parties to better understand what this would mean.
-
-The MIR team and thereby in extension Ubuntu continuously evolves the MIR ruling, for example we add rules based on painful lessons learned to avoid the same to happen again. In that regard some asks for testing, quality and such might be best practise now, but have not been fulfilled by packages that are in main for a long time.
-
-The proposed approach would be to:
-
-1. The MIR team would aim for a constant demand of e.g. "1 review per week per MIR member"
-   1. On one hand that means if new requests are assigned in a week that we make no progress on the backlog, but OTOH this keeps effort plannable)
-2. We'd run a trimmed down check which is a subset of our usual check (see below)
-3. As on the initial MIR review we might end up recommending a security (re-)review which goes into their queue at low prio
-
-## Special cases
-Special case - packges in main without an launchpad bug based MIR process.
-Some older cases do not have anything for auditability, for those we'll reach out to the [owning team](http://reqorts.qa.ubuntu.com/reports/m-r-package-team-mapping.html) and ask to file an MIR as they should ask (and answer) themselfe the same questions we do on a modern MIR.
-
-## Progress
-
-We do not expect this to be quick, there are so many old packages in main that do not even have any trace how they got promoted.
-But if we never start it will never be better. So instead of holding back, we need to just start at some point.
-
-## Process
-
-We'd add (doing so is a TODO) a query that helps us to spot packages in main for the longest time without having a recent update on their MIR bugs - out of that pool we'd then assign in each weekly team meeting.
-
-
-```
-TODO: Re-review for Package: TBDSRC
-
-[Summary]
-TODO: WRITE - TBD The essence of the review result from the MIR POV
-TODO-A: MIR team ACK - no extra work needed
-TODO-B: MIR team NACK - this needs to get out of main
-TODO-C: MIR team ACK under the constraint to resolve the below listed
-TODO-C: required TODOs and as much as possible having a look at the
-TODO-C: recommended TODOs.
-
-TODO-A: This does need a security re-review, so I'll assign ubuntu-security
-TODO-B: This does not need a security re-review
-
-Required TODOs:
-TODO: - TBD (Please add them numbered for later reference)
-Recommended TODOs:
-TODO: - TBD (Please add them numbered for later reference)
-
-[Duplication]
-RULE: It might have been unique back when added, but no more these days
-TODO: There is no other package in main providing the same functionality.
-
-RULE: none of these section matters for things already in main
-RULE: [Dependencies]
-RULE: [Embedded sources and static linking]
-
-[Security]
-RULE: - Determine if the package may have security implications or history.
-RULE:   Err on the side of caution and let security review it as well if in doubt.
-
-OK:
-TODO: - history of CVEs does still not look too concerning
-TODO: - does not run a daemon as root
-TODO: - does not use webkit1,2
-TODO: - does not use lib*v8 directly
-TODO: - does not parse data formats (files [images, video, audio,
-TODO:   xml, json, asn.1], network packets, structures, ...) from
-TODO:   an untrusted source.
-TODO: - does not open a port/socket
-TODO: - does not process arbitrary web content
-TODO: - does not use centralized online accounts
-TODO: - does not integrate arbitrary javascript into the desktop
-TODO: - does not deal with system authentication (eg, pam), etc)
-TODO: - does not deal with security attestation (secure boot, tpm, signatures)
-TODO: - does not deal with cryptography (en-/decryption, certificates, signing, ...)
-TODO: - no use of sudo, gksu, pkexec, or LD_LIBRARY_PATH (usage is OK inside
-TODO:   tests)
-TODO: - no use of user nobody
-TODO: - no use of setuid
-TODO: - use of setuid, but ok because TBD (prefer systemd to set those
-TODO:   for services)
-
-
-TODO-A: Problems:
-TODO-A: - TBD
-TODO-B: Problems: None
-
-[Common blockers]
-RULE: - There are plenty of testing requirements, hopefully already resolved
-RULE:   by the reporter upfront, see "Quality assurance - testing" section of
-RULE:   the Main Inclusion requirements
-
-OK:
-TODO-A: - d/copyright still reasonable for todays code?
-TODO-B: - The code has changed a lot since d/copyright was written, please adapt
-TODO: - does have a test suite that runs at build time
-TODO:   - test suite fails will fail the build upon error.
-TODO: - does have a non-trivial test suite that runs as autopkgtest
-TODO: - This does needs special HW or process for testing as documented,
-TODO    have those been followed correctly?
-
-TODO-A: Problems:
-TODO-A: - TBD
-TODO-B: Problems: None
-
-[Packaging red flags]
-RULE: - Does Ubuntu carry a non necessary delta?
-RULE: - If it's a library, does it either have a symbols file or use an empty
-RULE:   argument to dh_makeshlibs -V? (pass such a patch on to Debian, but
-RULE:   don't block on it).
-RULE:   Note that for C++, see https://wiki.ubuntu.com/DailyRelease/FAQ
-RULE:   for a method to demangle C++ symbols files.
-RULE: - Does it have a watch file? (If relevant, e.g. non-native)
-RULE: - Is its update history slow or sporadic?
-RULE: - Is the current release packaged?
-RULE: - Will entering main make it harder for the people currently keeping it
-RULE:   up to date? (i.e. are they only MOTUs?)
-RULE: - Lintian warnings
-RULE: - Is debian/rules a mess? Ideally it uses dh and overrides to make it as
-RULE:   tiny as possible.
-RULE: - If a package shall be promoted it should NOT be on the lto-disabled
-RULE:   list, but the fix, or the work-around should be directly in the package
-RULE:   to enforce maintainer awareness and make it more visible to anyone
-RULE:   looking at the package - see https://wiki.ubuntu.com/ToolChain/LTO.
-
-OK:
-TODO-A: - Ubuntu does not carry a delta
-TODO-B: - Ubuntu does carry a delta, but it is reasonable and maintenance under
-TODO-B:   control
-TODO-C: - Ubuntu does carry delta and it seems it could be simplified or upstreamed
-TODO-A: - debian/watch is present and looks ok
-TODO-B: - debian/watch is not present but also not needed in this case
-TODO: - Upstream update history is (good/slow/sporadic)
-TODO: - Debian/Ubuntu update history is (good/slow/sporadic)
-TODO: - the current release is packaged
-TODO: - no massive Lintian warnings
-TODO: - no Errors/warnings during the build
-TODO: - no important open bugs (crashers, etc) in Debian or Ubuntu
-TODO: - no dependency on webkit, qtwebkit, seed or libgoa-*
-
-TODO-A: Problems:
-TODO-A: - TBD
-TODO-B: Problems: None
+[Re-Review*]
+TODO*: Have defined manual testplans been demonstrated to be executed well?
+TODO-A*: - d/copyright seems still reasonable for todays code
+TODO-B*: - The code has changed a lot since d/copyright was written, please adapt
+TODO*: - debian/rules is following modern practice e.g. using dh tooling
 ```
 
 # MIR Team weekly status meeting

--- a/README.md
+++ b/README.md
@@ -852,6 +852,150 @@ TODO-A: - TBD
 TODO-B: Problems: None
 ```
 
+
+# Re-Reviewing an approved package
+
+Right now this is **not active**, it is - so far - a documentation of the intent to do so helping all involved parties to better understand what this would mean.
+
+The MIR team and thereby in extension Ubuntu continuously evolves the MIR ruling, for example we add rules based on painful lessons learned to avoid the same to happen again. In that regard some asks for testing, quality and such might be best practise now, but have not been fulfilled by packages that are in main for a long time.
+
+The proposed approach would be to:
+
+1. The MIR team would aim for a constant demand of e.g. "1 review per week per MIR member"
+   1. On one hand that means if new requests are assigned in a week that we make no progress on the backlog, but OTOH this keeps effort plannable)
+2. We'd run a trimmed down check which is a subset of our usual check (see below)
+3. As on the initial MIR review we might end up recommending a security (re-)review which goes into their queue at low prio
+
+## Special cases
+Special case - packges in main without an launchpad bug based MIR process.
+Some older cases do not have anything for auditability, for those we'll reach out to the [owning team](http://reqorts.qa.ubuntu.com/reports/m-r-package-team-mapping.html) and ask to file an MIR as they should ask (and answer) themselfe the same questions we do on a modern MIR.
+
+## Progress
+
+We do not expect this to be quick, there are so many old packages in main that do not even have any trace how they got promoted.
+But if we never start it will never be better. So instead of holding back, we need to just start at some point.
+
+## Process
+
+We'd add (doing so is a TODO) a query that helps us to spot packages in main for the longest time without having a recent update on their MIR bugs - out of that pool we'd then assign in each weekly team meeting.
+
+
+```
+TODO: Re-review for Package: TBDSRC
+
+[Summary]
+TODO: WRITE - TBD The essence of the review result from the MIR POV
+TODO-A: MIR team ACK - no extra work needed
+TODO-B: MIR team NACK - this needs to get out of main
+TODO-C: MIR team ACK under the constraint to resolve the below listed
+TODO-C: required TODOs and as much as possible having a look at the
+TODO-C: recommended TODOs.
+
+TODO-A: This does need a security re-review, so I'll assign ubuntu-security
+TODO-B: This does not need a security re-review
+
+Required TODOs:
+TODO: - TBD (Please add them numbered for later reference)
+Recommended TODOs:
+TODO: - TBD (Please add them numbered for later reference)
+
+[Duplication]
+RULE: It might have been unique back when added, but no more these days
+TODO: There is no other package in main providing the same functionality.
+
+RULE: none of these section matters for things already in main
+RULE: [Dependencies]
+RULE: [Embedded sources and static linking]
+
+[Security]
+RULE: - Determine if the package may have security implications or history.
+RULE:   Err on the side of caution and let security review it as well if in doubt.
+
+OK:
+TODO: - history of CVEs does still not look too concerning
+TODO: - does not run a daemon as root
+TODO: - does not use webkit1,2
+TODO: - does not use lib*v8 directly
+TODO: - does not parse data formats (files [images, video, audio,
+TODO:   xml, json, asn.1], network packets, structures, ...) from
+TODO:   an untrusted source.
+TODO: - does not open a port/socket
+TODO: - does not process arbitrary web content
+TODO: - does not use centralized online accounts
+TODO: - does not integrate arbitrary javascript into the desktop
+TODO: - does not deal with system authentication (eg, pam), etc)
+TODO: - does not deal with security attestation (secure boot, tpm, signatures)
+TODO: - does not deal with cryptography (en-/decryption, certificates, signing, ...)
+TODO: - no use of sudo, gksu, pkexec, or LD_LIBRARY_PATH (usage is OK inside
+TODO:   tests)
+TODO: - no use of user nobody
+TODO: - no use of setuid
+TODO: - use of setuid, but ok because TBD (prefer systemd to set those
+TODO:   for services)
+
+
+TODO-A: Problems:
+TODO-A: - TBD
+TODO-B: Problems: None
+
+[Common blockers]
+RULE: - There are plenty of testing requirements, hopefully already resolved
+RULE:   by the reporter upfront, see "Quality assurance - testing" section of
+RULE:   the Main Inclusion requirements
+
+OK:
+TODO-A: - d/copyright still reasonable for todays code?
+TODO-B: - The code has changed a lot since d/copyright was written, please adapt
+TODO: - does have a test suite that runs at build time
+TODO:   - test suite fails will fail the build upon error.
+TODO: - does have a non-trivial test suite that runs as autopkgtest
+TODO: - This does needs special HW or process for testing as documented,
+TODO    have those been followed correctly?
+
+TODO-A: Problems:
+TODO-A: - TBD
+TODO-B: Problems: None
+
+[Packaging red flags]
+RULE: - Does Ubuntu carry a non necessary delta?
+RULE: - If it's a library, does it either have a symbols file or use an empty
+RULE:   argument to dh_makeshlibs -V? (pass such a patch on to Debian, but
+RULE:   don't block on it).
+RULE:   Note that for C++, see https://wiki.ubuntu.com/DailyRelease/FAQ
+RULE:   for a method to demangle C++ symbols files.
+RULE: - Does it have a watch file? (If relevant, e.g. non-native)
+RULE: - Is its update history slow or sporadic?
+RULE: - Is the current release packaged?
+RULE: - Will entering main make it harder for the people currently keeping it
+RULE:   up to date? (i.e. are they only MOTUs?)
+RULE: - Lintian warnings
+RULE: - Is debian/rules a mess? Ideally it uses dh and overrides to make it as
+RULE:   tiny as possible.
+RULE: - If a package shall be promoted it should NOT be on the lto-disabled
+RULE:   list, but the fix, or the work-around should be directly in the package
+RULE:   to enforce maintainer awareness and make it more visible to anyone
+RULE:   looking at the package - see https://wiki.ubuntu.com/ToolChain/LTO.
+
+OK:
+TODO-A: - Ubuntu does not carry a delta
+TODO-B: - Ubuntu does carry a delta, but it is reasonable and maintenance under
+TODO-B:   control
+TODO-C: - Ubuntu does carry delta and it seems it could be simplified or upstreamed
+TODO-A: - debian/watch is present and looks ok
+TODO-B: - debian/watch is not present but also not needed in this case
+TODO: - Upstream update history is (good/slow/sporadic)
+TODO: - Debian/Ubuntu update history is (good/slow/sporadic)
+TODO: - the current release is packaged
+TODO: - no massive Lintian warnings
+TODO: - no Errors/warnings during the build
+TODO: - no important open bugs (crashers, etc) in Debian or Ubuntu
+TODO: - no dependency on webkit, qtwebkit, seed or libgoa-*
+
+TODO-A: Problems:
+TODO-A: - TBD
+TODO-B: Problems: None
+```
+
 # MIR Team weekly status meeting
 
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ re-check everything (they could, but they do not have to) while other
 things only are important on a re-check.
 For that there is a section *[Re-Review]* which has entries only needed for
 that.
-Furthermore any `TODO:` entry that shall be re-checked ona re-review has
+Furthermore any `TODO:` entry that shall be re-checked on a re-review has
 a `*` added before the colon. So it would appear as `TODO*:` or `TODO-A*:`
 respectively.
 That allows for easy filtering while not having redundant rules.
@@ -559,10 +559,10 @@ summary at the top).
 # Re-Reviewing an approved package
 
 The MIR team and thereby in extension Ubuntu continuously evolves the MIR
-ruling. For example, we add rules based on painful lessons learned to avoid
-the same from happening again. In that regard the demand for testing, quality
-and so on might be best practice now, but have not been fulfilled by packages
-that are in main for a long time.
+expectations and guidelines. For example, we add rules based on painful lessons
+learned to avoid the same from happening again. In that regard the demand for
+testing, quality and so on might be best practice now, but have not been
+fulfilled by packages that are in main for a long time.
 
 The proposed approach would be to:
 
@@ -578,7 +578,7 @@ The proposed approach would be to:
 ## Packages without a MIR bug
 
 This is a special case for things that are in main for quite some time.
-Those packages are in main without an launchpad bug based MIR process.
+Those packages are in main without a launchpad bug based MIR process.
 Some have mailing list posts which can serve as a base, but some have
 nothing at all for auditability.
 
@@ -589,7 +589,7 @@ creating a MIR bug for this package with this being the initial input.
 Then we will reach out to the [owning team](http://reqorts.qa.ubuntu.com/reports/m-r-package-team-mapping.html)
 and ask them to look at what we found and also ask them to reply on the bug
 with a full new `MIR` template. That shall help to ensure the owning teams
-point of view is documented as they should ask (and answer) themselfe
+point of view is documented as they should ask (and answer) themselves
 the same questions we expect them to do on any modern MIR.
 
 ## Progress and Expectations
@@ -668,8 +668,8 @@ RULE:   $ rmadison -c main {all,packages,that,look,like,duplicates}
 RULE: If any of them are reported to be in main check in detail if they cover
 RULE: indeed the same use case as the package this MIR is about.
 RULE: On re-review finding duplication might lead to considerations to drop
-RULE: one of the two. They might not have been unifiably back then, but might
-RULE: be nowadays
+RULE: one of the two. back in the day it might have been impossible to pick
+RULE: and support just one, but that might have changed since then.
 TODO*: There is no other package in main providing the same functionality.
 
 [Dependencies]
@@ -894,6 +894,10 @@ TODO*: - symbols tracking is in place
 TODO*: - symbols tracking not applicable for this kind of code.
 TODO-A*: - debian/watch is present and works well
 TODO-B*: - debian/watch is not present but also not needed (e.g. native)
+RULE: - On a re-review the bug history will be interesting again, it might show
+RULE:   that this was abandoned by upstream, Debian or even Ubuntu. While on the
+RULE:   other hand an insight might be that a package is more costly to maintain
+RULE:   than everyone assumed.
 TODO*: - Upstream update history is (good/slow/sporadic)
 TODO*: - Debian/Ubuntu update history is (good/slow/sporadic)
 TODO*: - the current release is packaged


### PR DESCRIPTION
In the last sprint a thought that has come up is the general desire to take our mission of "quality in main" serious and that actually re-reviews of packages already in main would need to be part of that.

This starts to document what we could do to start the discussion as only about half the team was in the in-person session.

The rules are 60% subset of the iniital MIR rules and 10% slight modifications or small additions. It might make more sense to not create a second redundant template and instead somehow "mark" those that shall be "also done" or "only done" on re-reviews in the original template. Open for suggestions, as I said this is only meant to be a draft to get the ball rolling.