### PR TITLE
Fix spell checker errors

### DIFF
--- a/.github/actions/spelling/advice.md
+++ b/.github/actions/spelling/advice.md
@@ -7,8 +7,8 @@ By default the suggested command will add the listed items to the <code>.github/
 
 If a listed items is
 * ... **misspelled**, then please *correct* them instead of changing the spell checker configuration.
-* ... an *actual* word/term that has a high probability of showing up in future contributions, please add it to the [`allowed words`](/.github/actions/spelling/allow).
-* ... an term/word that just you use or shouldn't generally be accepted, please add it to [`.github/actions/spelling/expect.txt`](/.github/actions/spelling/expect.txt).
+* ... an *actual* word/term that has a high probability of showing up in future contributions, please add it to [`.github/actions/spelling/allow`](https://github.com/canonical/ubuntu-mir/tree/main/.github/actions/spelling/allow).
+* ... an term/word that just you use or shouldn't generally be accepted, please add it to [`.github/actions/spelling/expect.txt`](https://github.com/canonical/ubuntu-mir/tree/main/.github/actions/spelling/expect.txt).
 
 See the `README.md` in each directory for more information.
 

--- a/.github/actions/spelling/allow/formats.txt
+++ b/.github/actions/spelling/allow/formats.txt
@@ -54,6 +54,8 @@ svg
 tex
 toml
 typescript
+url
+urls
 visual
 webassembly
 xhtml

--- a/.github/actions/spelling/allow/misc.txt
+++ b/.github/actions/spelling/allow/misc.txt
@@ -1,6 +1,5 @@
 ack
 acks
-architetcures
 auditability
 buildmode
 buildsystem

--- a/.github/actions/spelling/allow/misc.txt
+++ b/.github/actions/spelling/allow/misc.txt
@@ -32,4 +32,6 @@ vendored
 vendoring
 vendorized
 wiki
+workaround
+workarounds
 www

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The package must fulfill the following requirements.
 [Availability]
 TODO: The package TBDSRC is already in Ubuntu universe.
 TODO: The package TBDSRC build for the architectures it is designed to work on.
-TODO: It currently builds and works for architetcures: TBD
+TODO: It currently builds and works for architectures: TBD
 TODO: Link to package https://launchpad.net/ubuntu/+source/TBDSRC
 
 [Rationale]


### PR DESCRIPTION
After the merge of #18 and #19, spell-checker found some missing words that were not fixed in #18. I also noticed that the links in the advice template were not working.

Changes:
* I added the missing words (`urls`, `workaround`) to the allowed words list.
* I fixed the broken links in the advice template.

Note: I replace the links with absolute links. They will always point to this repo instead of the advice template in the PR branch. I could not figure out how to create working relative links. 