### PR TITLE
Greet new contributers on first issue/pr

### DIFF
--- a/.github/actions/spelling/allow/README.md
+++ b/.github/actions/spelling/allow/README.md
@@ -12,7 +12,7 @@ if you come up with a better system.
 
 | File | Description |
 | ---- | ----------- |
-| [architectures](architectures.txt) | architecture identifiers like `risc-v`  |
+| [architectures](architectures.txt) | architecture identifiers like `riscv`  |
 | [canonical](canonical.txt) | words/terms related to Canonical, like internal systems or products |
 | [contributors](contributors.txt) | usernames of contributors (that show up in the [`README.md`](../../../../README.md))  |
 | [debian](debian.txt) | debian related terms like `sid` |

--- a/.github/actions/spelling/allow/README.md
+++ b/.github/actions/spelling/allow/README.md
@@ -1,6 +1,6 @@
 # Allowed Words
 
-The `*.txt` files contained in this directory extend the dictonary provided by 
+The `*.txt` files contained in this directory extend the dictionary provided by 
 [`check-spelling`](https://github.com/check-spelling/check-spelling).
 
 Add new words to the respective categories. Feel free to recategorize the words 

--- a/.github/actions/spelling/allow/architectures.txt
+++ b/.github/actions/spelling/allow/architectures.txt
@@ -12,6 +12,7 @@ intel
 powerpc
 powerpc64
 ppc64el
+risc
 riscv 
 riscv64
 s390x

--- a/.github/actions/spelling/allow/architectures.txt
+++ b/.github/actions/spelling/allow/architectures.txt
@@ -13,7 +13,7 @@ powerpc
 powerpc64
 ppc64el
 risc
-riscv 
+riscv
 riscv64
 s390x
 x64

--- a/.github/actions/spelling/allow/formats.txt
+++ b/.github/actions/spelling/allow/formats.txt
@@ -61,3 +61,4 @@ webassembly
 xhtml
 xml
 yaml
+yml

--- a/.github/actions/spelling/allow/misc.txt
+++ b/.github/actions/spelling/allow/misc.txt
@@ -39,4 +39,5 @@ wiki
 workaround
 workarounds
 workflow
+workflows
 www

--- a/.github/actions/spelling/allow/misc.txt
+++ b/.github/actions/spelling/allow/misc.txt
@@ -38,4 +38,5 @@ vendorized
 wiki
 workaround
 workarounds
+workflow
 www

--- a/.github/actions/spelling/allow/misc.txt
+++ b/.github/actions/spelling/allow/misc.txt
@@ -11,6 +11,7 @@ demangle
 executables
 foss
 infographic
+metadata
 nack
 nacks
 oss

--- a/.github/actions/spelling/allow/misc.txt
+++ b/.github/actions/spelling/allow/misc.txt
@@ -32,6 +32,7 @@ transitioning
 upstream
 upstreamed
 upstreaming
+usernames
 vendored
 vendoring
 vendorized

--- a/.github/actions/spelling/allow/software.txt
+++ b/.github/actions/spelling/allow/software.txt
@@ -14,6 +14,7 @@ gksu
 grep
 gtk
 intltool
+irc
 jira
 libgoa
 libhunt

--- a/.github/actions/spelling/allow/ubuntu-codenames.txt
+++ b/.github/actions/spelling/allow/ubuntu-codenames.txt
@@ -4,6 +4,8 @@ badger
 beaver
 bionic
 breezy
+codename
+codenames
 cosmic
 cuttlefish
 dapper

--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -59,5 +59,6 @@ ignore$
 \.woff2?$
 \.xlsx?$
 \.zip$
-^\.github/actions/spelling/
-^\Q.github/workflows/spelling.yml\E$
+^\.github\/actions\/spelling\/candidate\.patterns$
+^\.github\/actions\/spelling\/line_forbidden\.patterns$
+^\.github\/actions\/spelling\/.+\.txt$

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -2,6 +2,7 @@ datetime
 endmeeting
 Hrn
 malloc
+markdownlint
 meetingology
 openwall
 pkgname

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,4 +1,6 @@
+datetime
 endmeeting
+Hrn
 malloc
 meetingology
 openwall
@@ -8,4 +10,3 @@ sprintf
 SRCPKG
 startmeeting
 TBDSRC
-Hrn

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -14,8 +14,8 @@ jobs:
         issue-message: |-
           Thank you so much for creating your first issue and therefore improving the Ubuntu MIR documentation!
           
-          Please also attend the next weekly MIR Team meeting (Tuesdays 15:30-16:00 GMT) on our IRC (`irc.libera.chat`) in the `#ubuntu-meeting` channel to discuss your issue with the MIR Team. You can follow these [instructions](https://libera.chat/guides/connect) on how to connect to `irc.libera.chat`.
+          Please also attend the next weekly MIR Team meeting (every Tuesday at <time datetime="T16:30+01:00">16:30 CET</time> on the IRC Server `irc.libera.chat` in the `#ubuntu-meeting` channel) to discuss your issue with the MIR Team. You can follow these [instructions](https://libera.chat/guides/connect) on how to connect to `irc.libera.chat`.
         pr-message:  |-
           Thank you so much for creating your first pull request and therefore improving the Ubuntu MIR documentation! We hope this is only the first in a long list of contributions :)
           
-          Please also attend the next weekly MIR Team meeting (Tuesdays 15:30-16:00 GMT) on our IRC (`irc.libera.chat`) in the `#ubuntu-meeting` channel to discuss your pull request with the MIR Team. You can follow these [instructions](https://libera.chat/guides/connect) on how to connect to `irc.libera.chat`.
+          Please also attend the next weekly MIR Team meeting (every Tuesday at <time datetime="T16:30+01:00">16:30 CET</time> on the IRC Server `irc.libera.chat` in the `#ubuntu-meeting` channel) to discuss your pull request with the MIR Team. You can follow these [instructions](https://libera.chat/guides/connect) on how to connect to `irc.libera.chat`.

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,21 @@
+name: Greet new Contributor
+
+on: [pull_request, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Welcome Message 
+      uses: actions/first-interaction@v1
+      continue-on-error: true
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: |-
+          Thank you so much for creating your first issue and therefore improving the Ubuntu MIR documentation!
+          
+          Please also attend the next weekly MIR Team meeting (Tuesdays 15:30-16:00 GMT) on our IRC (`irc.libera.chat`) in the `#ubuntu-meeting` channel to discuss your issue with the MIR Team. You can follow these [instructions](https://libera.chat/guides/connect) on how to connect to `irc.libera.chat`.
+        pr-message:  |-
+          Thank you so much for creating your first pull request and therefore improving the Ubuntu MIR documentation! We hope this is only the first in a long list of contributions :)
+          
+          Please also attend the next weekly MIR Team meeting (Tuesdays 15:30-16:00 GMT) on our IRC (`irc.libera.chat`) in the `#ubuntu-meeting` channel to discuss your pull request with the MIR Team. You can follow these [instructions](https://libera.chat/guides/connect) on how to connect to `irc.libera.chat`.

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         suppress_push_for_open_pull_request: 1
         checkout: true
-        check_file_names: 1
+        check_file_names: 0
         spell_check_this: check-spelling/spell-check-this@prerelease
         post_comment: 0
         use_magic_file: 1

--- a/README.md
+++ b/README.md
@@ -969,8 +969,11 @@ TODO-B: Problems: None
 # MIR Team weekly status meeting
 
 
-The MIR Team holds weekly meetings on Tuesdays, at 4.30 PM CET, in
-libera.chat #ubuntu-meeting.
+The MIR Team holds weekly meetings every Tuesday at
+<time datetime="T16:30+01:00">16:30 CET</time> on the IRC Server
+`irc.libera.chat` in the `#ubuntu-meeting` channel. You can follow these
+[instructions](https://libera.chat/guides/connect) on how to connect to
+`irc.libera.chat`.
 
 The meeting is meant to help to facilitate
 
@@ -1070,7 +1073,7 @@ we can do two things:
 
 We welcome everyone who wants to improve the Ubuntu MIR documentation! Whether you've found a typo, have a suggestion for improving existing content, or want to add new content, we'd love to hear from you.
 
-To contribute, simply submit a pull request with your changes or create an issue. Please also attend the weekly MIR Team meeting (Tuesdays 15:30-16:00 GMT) on our [IRC](https://wiki.ubuntu.com/IRC/ChannelList) in the [#ubuntu-meeting](https://wiki.ubuntu.com/BeginnersTeam/Meetings) channel to discuss your issue with the MIR Team.
+To contribute, simply submit a pull request with your changes or create an issue. Please also attend the weekly MIR Team meeting (every Tuesday at <time datetime="T16:30+01:00">16:30 CET</time> on the IRC `irc.libera.chat` in the `#ubuntu-meeting` channel) to discuss your issue with the MIR Team. You can follow these [instructions](https://libera.chat/guides/connect) on how to connect to `irc.libera.chat`.
 
 ### Code of Conduct
 


### PR DESCRIPTION
This GitHub Action will write a comment to the first issue/pr of a new contributor. Aside from just being a welcome message it also reminds people to attend the next `#ubuntu-meeting` and gives instructions how to join the `irc.libera.chat` IRC Server.