### PR TITLE
security: add timeline, contact, and priority info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,11 +1105,11 @@ we can do two things:
 
 ## Security Reviews
 
-Security team MIRs are laborious and require lead time. Make MIR requests as early in a release cycle as possible, ideally well before Feature Freeze. For a MIR to be considered for a release, it must be assigned to the Security team (by the MIR team) before Beta Freeze. This does not guarantee that a secuirty review can be completed by Final Release. Ask the director of Security for exceptions.
+Security team MIRs are laborious and require lead time. Make MIR requests as early in a release cycle as possible, ideally well before Feature Freeze. For a MIR to be considered for a release, it must be assigned to the Security team (by the MIR team) before Beta Freeze. This does not guarantee that a security review can be completed by Final Release. Ask the director of Security for exceptions.
 
 The best ways to contact the Security team about MIRs is the [MIR / Audits Jira Page](https://warthogs.atlassian.net/jira/software/c/projects/SEC/boards/594) or through the Mattermost channels `~mir-security-review-priority` or `~security`.
 
-Teams are encouarged to set the relative importance of MIRs they own on the [MIR / Audits Jira Page](https://warthogs.atlassian.net/jira/software/c/projects/SEC/boards/594). Security attempts to work across and prioritize all teams equally. Jira priority drives the order we work on MIRs.
+Teams are encouraged to set the relative importance of MIRs they own on the [MIR / Audits Jira Page](https://warthogs.atlassian.net/jira/software/c/projects/SEC/boards/594). Security attempts to work across and prioritize all teams equally. Jira priority drives the order we work on MIRs.
 
 ## Bug Lists
 

--- a/README.md
+++ b/README.md
@@ -1103,6 +1103,14 @@ we can do two things:
 1. List all distinct binary packages that should be promoted.  Often a source package will have binary packages that aren't actually needed in main.  Things like `-doc`, `-autopilot` or `-dbgsym`.  These can stay in universe, and it is a kindness to list only the packages we need for the archive team member that does the promotion.
 1. Recommend the owning team to add their corresponding team bug subscriber during the MIR process.
 
+## Security Reviews
+
+Security team MIRs are laborious and require lead time. Make MIR requests as early in a release cycle as possible, ideally well before Feature Freeze. For a MIR to be considered for a release, it must be assigned to the Security team (by the MIR team) before Beta Freeze. This does not guarantee that a secuirty review can be completed by Final Release. Ask the director of Security for exceptions.
+
+The best ways to contact the Security team about MIRs is the [MIR / Audits Jira Page](https://warthogs.atlassian.net/jira/software/c/projects/SEC/boards/594) or through the Mattermost channels `~mir-security-review-priority` or `~security`.
+
+Teams are encouarged to set the relative importance of MIRs they own on the [MIR / Audits Jira Page](https://warthogs.atlassian.net/jira/software/c/projects/SEC/boards/594). Security attempts to work across and prioritize all teams equally. Jira priority drives the order we work on MIRs.
+
 ## Bug Lists
 
 * [All MIR bugs](https://bugs.launchpad.net/~ubuntu-mir)


### PR DESCRIPTION
Late in the Mantic cycle Security approved three MIRs ([LP#2030482](https://bugs.launchpad.net/ubuntu/+source/s390-tools/+bug/2030482) and two in [LP#2038942](https://bugs.launchpad.net/ubuntu/+source/qrtr/+bug/2038942)). From this Security learned that we need to improve our documentation and set expectations.

@setharnold does Beta Freeze sound appropriate to you? That is tight, but feels workable.

@frank-heimes @xnox 