### PR TITLE
fix: broken rendering of flowchart html tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ confusion, and indicate the next course of action on a MIR bug.
 
 ```mermaid
 %% mermaid flowcharts documentation: https://mermaid.js.org/syntax/flowchart.html
-%%{ init: { 'flowchart': { 'curve': 'monotoneY' } } }%%
+%%{ init: { 'flowchart': { 'curve': 'monotoneY', 'htmlLabels': true } } }%%
 flowchart TD
     %% Styles
     classDef Invisible stroke-width:0,fill:#00000000 


### PR DESCRIPTION
I could not pin point when this was changed, but it looks like  that defining html labels now has to be explicitly enabled.

See: https://mermaid.js.org/syntax/flowchart.html

Fixes: https://github.com/canonical/ubuntu-mir/issues/48