### PR TITLE
Clarify unwanted deps check

### DIFF
--- a/.github/actions/spelling/allow/software.txt
+++ b/.github/actions/spelling/allow/software.txt
@@ -11,6 +11,7 @@ dpkg
 gettext
 github
 gksu
+GObject
 grep
 gtk
 intltool

--- a/.github/actions/spelling/allow/software.txt
+++ b/.github/actions/spelling/allow/software.txt
@@ -19,6 +19,7 @@ jira
 libgoa
 libhunt
 libjpeg
+libseed
 linkshared
 lintian
 makeshlibs

--- a/README.md
+++ b/README.md
@@ -1035,6 +1035,11 @@ RULE:    built binaries)
 TODO: - use of setuid, but ok because TBD (prefer systemd to set those
 TODO:   for services)
 TODO: - no important open bugs (crashers, etc) in Debian or Ubuntu
+RULE: Old dependencies, partially even still in main we want to get rid of over
+RULE: time. While they may be still there, we'd not want to add new
+RULE: dependencies. webkit = Web content engine library for GTK,
+RULE: qtwebkit = Web content engine library for Qt, libseed = GObject JavaScript
+RULE: bindings for the webkit engine
 TODO: - no dependency on webkit, qtwebkit or libseed
 TODO-A: - not part of the UI for extra checks
 TODO-B: - part of the UI, desktop file is ok


### PR DESCRIPTION
While fixing the "libseed" that was flagged in the spelling check I realized that we rarely explained well what (only short names) we want to avoid and why (some are in main, why do we not want them).

I decided to improve that situation by not only fixing the spelling check, but also the wording there.
Let me know what you think of it.