### PR TITLE
Rust: Make the tarball more reproducible

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,5 +1,6 @@
 admins
 adsys
+atime
 authd
 buildsystems
 bvn
@@ -7,6 +8,7 @@ bvr
 changelog
 codebases
 compat
+ctime
 CURDIR
 datetime
 debdiff
@@ -15,6 +17,7 @@ deps
 DESTDIR
 dmi
 endmeeting
+exthdr
 fdx
 fwupd
 Hrn
@@ -29,6 +32,7 @@ meetingology
 metapackage
 modalias
 modaliase
+mtime
 oem
 openwall
 parsechangelog

--- a/vendoring/Rust.md
+++ b/vendoring/Rust.md
@@ -66,7 +66,7 @@ vendor-deps:
         rm -rf $(CARGO_HOME)
 
 vendor-tarball: vendor-tarball-sanity-check vendor-deps
-        tar -caf ../$(VENDOR_TARBALL) $(CARGO_VENDOR_DIR)
+        tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime -caf ../$(VENDOR_TARBALL) $(CARGO_VENDOR_DIR)
 
 %:
         dh $@


### PR DESCRIPTION
These are the standard-ish options to pass here to get a reproducible tarball, except for compression which may not be; copied from my nullboot pre-build export.