### PR TITLE
template: force the requester to think about all binary packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,9 @@ RULE: We have seen requests that were mostly based on old "I said supported (a
 RULE: weakly defined term to begin with) in a contract, so it has to be in main"
 RULE: feelings, but with sometimes no true reason - neither technically nor
 RULE: helping the user base of Ubuntu. Hence we need to ask for that clearly.
-TODO: - The binary package TBD needs to be in main to achieve TBD
+TODO-A: - The binary packages TBD needs to be in main to achieve TBD
+TODO-A: - All other binary packages built by TBDSRC should remain in universe
+TODO-B: - All binary packages built by TBDSRC need to be in main to achieve TBD
 
 RULE: Reviews will take some time. Also the potential extra work out of review
 RULE: feedback from either MIR-team and/or security-team will take time.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ RULE: We have seen requests that were mostly based on old "I said supported (a
 RULE: weakly defined term to begin with) in a contract, so it has to be in main"
 RULE: feelings, but with sometimes no true reason - neither technically nor
 RULE: helping the user base of Ubuntu. Hence we need to ask for that clearly.
-TODO-A: - The binary packages TBD needs to be in main to achieve TBD
+TODO: - The binary packages TBD needs to be in main to achieve TBD
 TODO-A: - All other binary packages built by TBDSRC should remain in universe
 TODO-B: - All binary packages built by TBDSRC need to be in main to achieve TBD
 


### PR DESCRIPTION
While the RULE paragraph is already pretty good at this, having the template actually spell this out is beneficial for any reader that comes upon the MIR later on, e.g. while investigating component-mismatches.