### PR TITLE
Update README.md -- add meeting item for community agenda items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,9 @@ template:
 
 Ping for MIR meeting - didrocks joalif slyon sarnold cpaelzer mylesjp pushkarnk ( dviererbe )
 
+#topic add agenda items from the community
+Mission: Are there topics that we need to discuss in the Any Other Business section, or earlier?
+
 #topic current component mismatches
 Mission: Identify required actions and spread the load among the teams
 


### PR DESCRIPTION
2025-05-20 14:58:27 < bdrung> cpaelzer, suggestions for future MIR meeting: Add one topic at the beginning of the meeting to allow outsider to push topics to the agenda.