### PR TITLE
Update README.md - add poll for external topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,9 @@ template:
 
 Ping for MIR meeting - didrocks joalif slyon sarnold cpaelzer mylesjp pushkarnk ( dviererbe )
 
+# Awareness of external agenda items
+Mission: To be aware and potentially allocate the required time, poll if anyone attending has discussions that should be added to the agenda today.
+
 #topic current component mismatches
 Mission: Identify required actions and spread the load among the teams
 
@@ -1187,6 +1190,7 @@ Internal link
 #link https://warthogs.atlassian.net/jira/software/c/projects/SEC/boards/594
 
 #topic Any other business?
+Mission: catch-all chance for anything missed or not covered by the usual agenda items.
 
 #endmeeting
 ```


### PR DESCRIPTION
As suggested on the May 20th 2025 meeting, add a poll for external topics to avoid them having to wait and potentially miss the A-O-B section.